### PR TITLE
[codex] Fix M4 SMC temperature readings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- CPU temperature readings on M4-family Macs now use the generation-specific SMC sensor keys.
+
 ## [0.1.258] - 2026-07-26
 
 ### Changed

--- a/src-tauri/src/feature_health.rs
+++ b/src-tauri/src/feature_health.rs
@@ -505,23 +505,27 @@ async fn probe_redmine() -> FeatureHealth {
 }
 
 async fn probe_smc_blocking() -> FeatureHealth {
-    let (tx, rx) = oneshot::channel::<Result<(), String>>();
+    let (tx, rx) = oneshot::channel::<Result<String, String>>();
+    let chip_info = crate::metrics::get_chip_info();
     std::thread::spawn(move || {
-        let out = std::thread::spawn(|| {
-            macsmc::Smc::connect()
-                .map(|_| ())
-                .map_err(|e| format!("{e:?}"))
+        let out = std::thread::spawn(move || {
+            let mut smc = macsmc::Smc::connect().map_err(|e| format!("{e:?}"))?;
+            let mut reader = crate::metrics::smc_temperature::SmcTemperatureReader::default();
+            let reading = reader.read(&mut smc, &chip_info).ok_or_else(|| {
+                format!("SMC connected but no CPU temperature key matched {chip_info}")
+            })?;
+            Ok(format!(
+                "{:.1}°C via {}",
+                reading.value_celsius,
+                reading.keys.join(", ")
+            ))
         })
         .join()
         .unwrap_or_else(|_| Err("SMC thread panicked".into()));
         let _ = tx.send(out);
     });
     match tokio::time::timeout(PROBE_TIMEOUT, rx).await {
-        Ok(Ok(Ok(()))) => entry(
-            "SMC (temperature)",
-            HealthStatus::Ok,
-            Some("SMC driver reachable".into()),
-        ),
+        Ok(Ok(Ok(message))) => entry("SMC (temperature)", HealthStatus::Ok, Some(message)),
         Ok(Ok(Err(e))) => entry("SMC (temperature)", HealthStatus::Unavailable, Some(e)),
         Ok(Err(_)) => entry(
             "SMC (temperature)",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -648,6 +648,8 @@ fn run_internal(open_cpu_window: bool) {
                 // CRITICAL: Keep SMC connection alive in background thread (reuse for efficiency)
                 // SMC connection is not Sync, so we keep it thread-local
                 let mut smc_connection: Option<Smc> = None;
+                let mut smc_temperature_reader =
+                    metrics::smc_temperature::SmcTemperatureReader::default();
 
                 loop {
                     // Menu bar updates every 1-2 seconds (like Stats app) for responsive UI
@@ -724,11 +726,6 @@ fn run_internal(open_cpu_window: bool) {
                                 Ok(smc) => {
                                     smc_connection = Some(smc);
                                     debug3!("SMC connection established in background thread");
-                                    // OPTIMIZATION Phase 3: Update OnceLock to indicate SMC works
-                                    // This ensures can_read_temperature() returns true
-                                    if CAN_READ_TEMPERATURE.set(true).is_ok() {
-                                        debug3!("CAN_READ_TEMPERATURE set to true (SMC connection successful)");
-                                    }
                                 },
                                 Err(e) => {
                                     debug3!("Failed to connect to SMC: {:?}", e);
@@ -1154,13 +1151,13 @@ fn run_internal(open_cpu_window: bool) {
                             }
                         }
 
-                        // CRITICAL: Only read temperature every 20 seconds to reduce CPU usage
+                        // CRITICAL: Only read temperature periodically to reduce CPU usage
                         // all_data() iteration is VERY expensive - limit it as much as possible
                         // STEP 3: Temperature reading every 20s to save CPU
                         // Temperature doesn't change rapidly, so 20s is still responsive
                         let should_read_temp_now = if let Ok(mut last) = LAST_TEMP_UPDATE.lock() {
                             let should = last.as_ref()
-                                .map(|t| t.elapsed().as_secs() >= 20)
+                                .map(|t| t.elapsed() >= TEMP_READ_INTERVAL)
                                 .unwrap_or(true);
                             if should {
                                 *last = Some(std::time::Instant::now());
@@ -1174,86 +1171,29 @@ fn run_internal(open_cpu_window: bool) {
                         if should_read_temp_now {
                             // Read temperature using existing connection
                             if let Some(ref mut smc) = smc_connection {
-                                // First try standard cpu_temperature() method (works for M1/M2)
-                                let mut temp = 0.0;
-                                match smc.cpu_temperature() {
-                                    Ok(temps) => {
-                                        let die_temp: f64 = temps.die.into();
-                                        let prox_temp: f64 = temps.proximity.into();
-
-                                        // Priority: die > proximity
-                                        temp = if die_temp > 0.0 {
-                                            die_temp
-                                        } else if prox_temp > 0.0 {
-                                            prox_temp
-                                        } else {
-                                            0.0
-                                        };
-                                    },
-                                    Err(_) => {
-                                        // Standard method failed, continue to raw key reading
-                                    }
-                                }
-
-                                // If standard method returned 0.0, try reading M3 Max raw keys directly
-                                // These are the keys that exelban/stats uses for M3 Max
-                                if temp == 0.0 {
-                                    // Check if we've already discovered a working M3 key
-                                    let cached_key = M3_TEMP_KEY.lock().ok().and_then(|k| k.clone());
-
-                                    if let Some(key_name) = cached_key {
-                                        // CRITICAL: Use direct key reading instead of all_data() iteration
-                                        // This is MUCH more efficient - avoids iterating through all SMC keys
-                                        // Try to read the specific key directly
-                                        // Note: macsmc may not have direct key reading, so we'll limit all_data() usage
-                                        // Only call all_data() if we absolutely need to, and limit iteration
-                                        if let Ok(data_iter) = smc.all_data() {
-                                            for dbg in data_iter.flatten() {
-                                                if dbg.key == key_name {
-                                                    if let Ok(Some(macsmc::DataValue::Float(val))) = dbg.value {
-                                                        if val > 0.0 {
-                                                            temp = val as f64;
-                                                            debug3!("Temperature read from cached M3 key {}: {:.1}°C", key_name, temp);
-                                                            break;
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    } else {
-                                        // First time: discover which M3 key works
-                                        // CRITICAL: Only iterate through keys once, then cache the result
-                                        // Try known M3 Max temperature keys (same as exelban/stats uses)
-                                        let m3_keys = ["Tf04", "Tf09", "Tf0A", "Tf0B", "Tf0D", "Tf0E"];
-                                        if let Ok(data_iter) = smc.all_data() {
-                                            for dbg in data_iter.flatten() {
-                                                if m3_keys.contains(&dbg.key.as_str()) {
-                                                    if let Ok(Some(macsmc::DataValue::Float(val))) = dbg.value {
-                                                        if val > 0.0 {
-                                                            temp = val as f64;
-                                                            if let Ok(mut cached) = M3_TEMP_KEY.lock() {
-                                                                *cached = Some(dbg.key.clone());
-                                                                debug3!("Discovered working M3 temperature key: {} = {:.1}°C", dbg.key, temp);
-                                                            }
-                                                            break;
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-
-                                if temp > 0.0 {
+                                let chip_info = metrics::get_chip_info();
+                                if let Some(reading) =
+                                    smc_temperature_reader.read(smc, &chip_info)
+                                {
                                     // Update cache with new temperature and timestamp
                                     if let Ok(mut cache) = TEMP_CACHE.try_lock() {
-                                        *cache = Some((temp as f32, std::time::Instant::now()));
-                                        debug3!("Temperature updated in cache: {:.1}°C", temp);
+                                        *cache = Some((
+                                            reading.value_celsius,
+                                            std::time::Instant::now(),
+                                        ));
+                                        debug3!(
+                                            "Temperature updated in cache: {:.1}°C via {:?}",
+                                            reading.value_celsius,
+                                            reading.keys
+                                        );
                                     } else {
                                         debug3!("Temperature cache lock failed, skipping update");
                                     }
                                 } else {
-                                    debug3!("Temperature read returned 0.0 - no valid temperature found");
+                                    debug3!(
+                                        "No valid CPU temperature found for chip '{}'",
+                                        chip_info
+                                    );
                                     // Don't update cache - keep previous value if available
                                 }
                             }

--- a/src-tauri/src/metrics/mod.rs
+++ b/src-tauri/src/metrics/mod.rs
@@ -11,9 +11,9 @@
 //! All metrics are cached to reduce system load and improve performance.
 
 pub mod history;
+pub(crate) mod smc_temperature;
 
 use battery::{Manager as BatteryManager, State};
-use macsmc::Smc;
 use std::process::Command;
 use sysinfo::{Disks, System};
 use tauri::Manager;
@@ -468,48 +468,15 @@ fn extract_percentage_from_line(line: &str) -> Option<f32> {
 }
 
 pub fn can_read_temperature() -> bool {
-    // Check if we have a valid cached temperature (indicates SMC access works)
-    // This is more efficient than checking SMC directly
-    if let Ok(cache) = TEMP_CACHE.try_lock() {
-        if let Some((temp, timestamp)) = cache.as_ref() {
-            // If we have a recent temperature reading, SMC access works
-            // Increased from 10s to 20s to match the 15s reading frequency
-            if *temp > 0.0 && timestamp.elapsed().as_secs() < 20 {
-                debug3!(
-                    "can_read_temperature: true (from TEMP_CACHE with temp={:.1}°C)",
-                    *temp
-                );
-                return true;
-            }
-        }
-    }
-
-    // OPTIMIZATION Phase 3: Use OnceLock for faster access (no locking required)
-    *CAN_READ_TEMPERATURE.get_or_init(|| {
-        debug3!("can_read_temperature: First time check - trying SMC connection...");
-        let can_read = if let Ok(mut smc) = Smc::connect() {
-            // Connection succeeded - we can attempt to read (even if it returns 0.0)
-            match smc.cpu_temperature() {
-                Ok(_) => {
-                    // SMC read succeeded (even if temp is 0.0, the read worked)
-                    debug3!("SMC connection and read succeeded - can_read_temperature=true");
-                    true
-                }
-                Err(e) => {
-                    // SMC read failed
-                    debug3!("SMC read failed: {:?} - can_read_temperature=false", e);
-                    false
-                }
-            }
-        } else {
-            // SMC connection failed - can't read
-            debug3!("SMC connection failed - can_read_temperature=false");
-            false
-        };
-
-        debug3!("can_read_temperature: Cached result: {}", can_read);
-        can_read
-    })
+    TEMP_CACHE
+        .lock()
+        .ok()
+        .and_then(|cache| {
+            cache
+                .as_ref()
+                .map(|(temp, timestamp)| *temp > 0.0 && timestamp.elapsed() < TEMP_CACHE_MAX_AGE)
+        })
+        .unwrap_or(false)
 }
 
 // Get nominal CPU frequency using sysctl (cheap, no sudo required)
@@ -1755,20 +1722,17 @@ pub fn get_cpu_details() -> CpuDetails {
         has_battery,
     ) = {
         // Get cached access flags (fast OnceLock access, no blocking)
-        let _can_read_temp = CAN_READ_TEMPERATURE.get().copied().unwrap_or(false);
         let can_read_freq = CAN_READ_FREQUENCY.get().copied().unwrap_or(false);
         let can_read_cpu_p = CAN_READ_CPU_POWER.get().copied().unwrap_or(false);
         let can_read_gpu_p = CAN_READ_GPU_POWER.get().copied().unwrap_or(false);
 
         // CRITICAL: Read temperature from cache (updated by background thread)
         // Non-blocking read - returns 0.0 if cache is locked or stale
-        // Cache is valid for up to 20 seconds (background thread updates every 15 seconds)
+        // Keep a scheduling margin beyond the background sampling interval.
         let temperature = match TEMP_CACHE.try_lock() {
             Ok(cache) => {
                 if let Some((temp, timestamp)) = cache.as_ref() {
-                    // Only use cached value if it's fresh (less than 20 seconds old)
-                    // Increased from 10s to 20s to match the 15s reading frequency
-                    if timestamp.elapsed().as_secs() < 20 {
+                    if timestamp.elapsed() < TEMP_CACHE_MAX_AGE {
                         *temp
                     } else {
                         debug3!(

--- a/src-tauri/src/metrics/smc_temperature.rs
+++ b/src-tauri/src/metrics/smc_temperature.rs
@@ -1,0 +1,176 @@
+use macsmc::{DataValue, Smc};
+
+const MIN_VALID_TEMPERATURE_C: f32 = 10.0;
+const MAX_VALID_TEMPERATURE_C: f32 = 120.0;
+
+// Apple changes SMC sensor keys between SoC generations. Keep these lists model-scoped so a
+// similarly named sensor from another generation is never mistaken for a CPU temperature.
+const M3_CPU_TEMPERATURE_KEYS: &[&str] = &["Tf04", "Tf09", "Tf0A", "Tf0B", "Tf0D", "Tf0E"];
+const M4_CPU_TEMPERATURE_KEYS: &[&str] = &[
+    "Te05", "Te0S", "Te09", "Te0H", // efficiency clusters
+    "Tp01", "Tp05", "Tp09", "Tp0D", "Tp0V", "Tp0Y", "Tp0b", "Tp0e", // performance clusters
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AppleSiliconGeneration {
+    M3,
+    M4,
+    Other,
+}
+
+#[derive(Debug)]
+pub(crate) struct CpuTemperatureReading {
+    pub(crate) value_celsius: f32,
+    pub(crate) keys: Vec<String>,
+}
+
+#[derive(Default)]
+pub(crate) struct SmcTemperatureReader {
+    cached_keys: Vec<String>,
+}
+
+impl SmcTemperatureReader {
+    pub(crate) fn read(&mut self, smc: &mut Smc, chip_info: &str) -> Option<CpuTemperatureReading> {
+        match apple_silicon_generation(chip_info) {
+            AppleSiliconGeneration::M3 => self.read_raw_keys(smc, M3_CPU_TEMPERATURE_KEYS),
+            AppleSiliconGeneration::M4 => self.read_raw_keys(smc, M4_CPU_TEMPERATURE_KEYS),
+            AppleSiliconGeneration::Other => read_standard_temperature(smc),
+        }
+    }
+
+    fn read_raw_keys(
+        &mut self,
+        smc: &mut Smc,
+        generation_keys: &[&str],
+    ) -> Option<CpuTemperatureReading> {
+        if !self.cached_keys.is_empty() {
+            let cached_keys = self.cached_keys.clone();
+            let cached_key_refs: Vec<&str> = cached_keys.iter().map(String::as_str).collect();
+            if let Some(reading) = scan_temperature_keys(smc, &cached_key_refs) {
+                return Some(reading);
+            }
+            self.cached_keys.clear();
+        }
+
+        let reading = scan_temperature_keys(smc, generation_keys)?;
+        self.cached_keys.clone_from(&reading.keys);
+        Some(reading)
+    }
+}
+
+fn apple_silicon_generation(chip_info: &str) -> AppleSiliconGeneration {
+    if chip_info.contains("Apple M4") {
+        AppleSiliconGeneration::M4
+    } else if chip_info.contains("Apple M3") {
+        AppleSiliconGeneration::M3
+    } else {
+        AppleSiliconGeneration::Other
+    }
+}
+
+fn read_standard_temperature(smc: &mut Smc) -> Option<CpuTemperatureReading> {
+    let temperatures = smc.cpu_temperature().ok()?;
+    let die: f64 = temperatures.die.into();
+    let proximity: f64 = temperatures.proximity.into();
+    let value_celsius = [die as f32, proximity as f32]
+        .into_iter()
+        .find(|value| is_valid_temperature(*value))?;
+
+    Some(CpuTemperatureReading {
+        value_celsius,
+        keys: vec!["macsmc-standard".to_string()],
+    })
+}
+
+fn scan_temperature_keys(smc: &mut Smc, candidate_keys: &[&str]) -> Option<CpuTemperatureReading> {
+    let data = smc.all_data().ok()?;
+    let mut readings = Vec::new();
+
+    for item in data.flatten() {
+        if !candidate_keys.contains(&item.key.as_str()) {
+            continue;
+        }
+        if let Ok(Some(DataValue::Float(value))) = item.value {
+            if is_valid_temperature(value) {
+                readings.push((item.key, value));
+                if readings.len() == candidate_keys.len() {
+                    break;
+                }
+            }
+        }
+    }
+
+    average_readings(readings)
+}
+
+fn average_readings(readings: Vec<(String, f32)>) -> Option<CpuTemperatureReading> {
+    if readings.is_empty() {
+        return None;
+    }
+
+    let value_celsius =
+        readings.iter().map(|(_, value)| value).sum::<f32>() / readings.len() as f32;
+    let keys = readings.into_iter().map(|(key, _)| key).collect();
+    Some(CpuTemperatureReading {
+        value_celsius,
+        keys,
+    })
+}
+
+fn is_valid_temperature(value: f32) -> bool {
+    value.is_finite() && (MIN_VALID_TEMPERATURE_C..=MAX_VALID_TEMPERATURE_C).contains(&value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_m4_variants() {
+        assert_eq!(
+            apple_silicon_generation("Apple M4 · 10 cores"),
+            AppleSiliconGeneration::M4
+        );
+        assert_eq!(
+            apple_silicon_generation("Apple M4 Pro · 14 cores"),
+            AppleSiliconGeneration::M4
+        );
+        assert_eq!(
+            apple_silicon_generation("Apple M4 Max · 16 cores"),
+            AppleSiliconGeneration::M4
+        );
+    }
+
+    #[test]
+    fn keeps_m3_and_other_generations_separate() {
+        assert_eq!(
+            apple_silicon_generation("Apple M3 Max · 16 cores"),
+            AppleSiliconGeneration::M3
+        );
+        assert_eq!(
+            apple_silicon_generation("Apple M2 · 8 cores"),
+            AppleSiliconGeneration::Other
+        );
+    }
+
+    #[test]
+    fn averages_discovered_cpu_sensors() {
+        let reading = average_readings(vec![
+            ("Te05".to_string(), 40.0),
+            ("Tp01".to_string(), 50.0),
+            ("Tp05".to_string(), 60.0),
+        ])
+        .expect("valid readings");
+
+        assert_eq!(reading.value_celsius, 50.0);
+        assert_eq!(reading.keys, ["Te05", "Tp01", "Tp05"]);
+    }
+
+    #[test]
+    fn rejects_implausible_temperatures() {
+        assert!(!is_valid_temperature(0.0));
+        assert!(!is_valid_temperature(121.0));
+        assert!(!is_valid_temperature(f32::NAN));
+        assert!(is_valid_temperature(42.5));
+    }
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -20,7 +20,7 @@ use objc2::runtime::AnyObject;
 use objc2_app_kit::NSStatusItem;
 use std::cell::RefCell;
 use std::sync::{Mutex, OnceLock};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use sysinfo::{Disks, System};
 use tauri::AppHandle;
 
@@ -80,14 +80,15 @@ pub(crate) fn format_process_uptime() -> String {
 // Caches
 pub(crate) static CHIP_INFO_CACHE: OnceLock<String> = OnceLock::new();
 
-pub(crate) static CAN_READ_TEMPERATURE: OnceLock<bool> = OnceLock::new();
 pub(crate) static CAN_READ_FREQUENCY: OnceLock<bool> = OnceLock::new();
 pub(crate) static CAN_READ_CPU_POWER: OnceLock<bool> = OnceLock::new();
 pub(crate) static CAN_READ_GPU_POWER: OnceLock<bool> = OnceLock::new();
 
+pub(crate) const TEMP_READ_INTERVAL: Duration = Duration::from_secs(20);
+pub(crate) const TEMP_CACHE_MAX_AGE: Duration = Duration::from_secs(30);
+
 // Temperature cache: (temperature_value, last_update_timestamp)
 pub(crate) static TEMP_CACHE: Mutex<Option<(f32, Instant)>> = Mutex::new(None);
-pub(crate) static M3_TEMP_KEY: Mutex<Option<String>> = Mutex::new(None);
 
 // Frequency cache: (frequency_value_ghz, last_update_timestamp)
 pub(crate) static FREQ_CACHE: Mutex<Option<(f32, Instant)>> = Mutex::new(None);


### PR DESCRIPTION
## Summary

- add generation-aware CPU temperature sensor selection for M3- and M4-family Macs
- average all valid generation-specific CPU sensors and cache the discovered key set
- report SMC health only after reading an actual temperature value
- keep temperature cache validity slightly longer than the sampling interval to avoid transient `No data` states

## Root cause

The fallback path only scanned the M3 `Tf*` SMC keys. M4-family Macs use `Te*` efficiency-cluster and `Tp*` performance-cluster sensors, so the SMC connection succeeded while CPU temperature remained unavailable. The health probe only tested the connection and therefore reported a false positive.

## Validation

- `cargo check --locked`
- `cargo test --locked smc_temperature --lib` (4 passed)
- Release DMG build with Tauri
- `codesign --verify --deep --strict` on the packaged app
- mounted and launched the packaged app on a Mac mini (Mac16,10, Apple M4)
- observed valid readings across multiple sampling intervals with all 12 M4 keys and no return to `No data`

`cargo clippy --locked --lib -- -D warnings` still reports the existing warnings on `main`; this change does not introduce diagnostics in the new temperature module.

Closes #8
